### PR TITLE
Tweaked login flow to use X-Auth-Token session header instead of JWT …

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -78,12 +78,6 @@ export default {
     },
     created: function() {
         this.readAccessToken();
-        let token = sessionStorage.getItem("mlr-access-token");
-        if (token) {
-            axios.defaults.headers.common["Authorization"] = "Bearer " + token;
-        } else {
-            window.location = axios.defaults.baseURL + "util/login";
-        }
 
         EventBus.$on("snackbar-update", response => {
             this.showSnackbarMessage(response);
@@ -108,8 +102,10 @@ export default {
                 "mlrAccessToken"
             );
             if (accessToken) {
-                sessionStorage.setItem("mlr-access-token", accessToken);
+                axios.defaults.headers.common["X-Auth-Token"] = accessToken;
                 window.history.replaceState({}, document.title, "/");
+            } else {
+                window.location = axios.defaults.baseURL + "util/login";
             }
         },
         showSnackbarMessage(response) {


### PR DESCRIPTION
…Bearer token for Gateway requests.

Note that the session is no longer stored at all (even in session storage) and is just used to set the Axios header value on page load. This means that on every page reload/refresh the user will be sent through the Gateway to grab the session token again, but since tokens are short-lived this should probably happen anyways. It's very fast and pretty much invisible, so I don't think it hampers the experience at all but if anyone disagrees let me know.